### PR TITLE
Fixes to partial saves and the split mechanism.

### DIFF
--- a/States/BaseState.py
+++ b/States/BaseState.py
@@ -50,19 +50,19 @@ class State:
     def frameUpdate(self):
         pass
 
-    def onStarted(self,_):
+    def onStarted(self):
         pass
 
-    def onSplit(self,_):
+    def onSplit(self):
         pass
 
     def onComparisonChanged(self,_):
         pass
 
-    def onPaused(self,_):
+    def onPaused(self):
         pass
 
-    def onSplitSkipped(self,_):
+    def onSplitSkipped(self):
         pass
 
     def onReset(self):

--- a/States/PracticeState.py
+++ b/States/PracticeState.py
@@ -1,3 +1,4 @@
+from timeit import default_timer as timer
 from util import fileio
 from util import timeHelpers as timeh
 from States import BaseState
@@ -18,18 +19,16 @@ class State(BaseState.State):
             self.saveData["defaultComparisons"]["bestSegments"]["segments"][self.splitnum])
         self.unSaved = False
 
-    def frameUpdate(self, time):
+    def frameUpdate(self):
         if not (self.started and not self.runEnded):
             return 1
-        self.segmentTime = time - self.starttime
+        self.segmentTime = timer() - self.starttime
 
     ##########################################################
     # Do the state update when the run starts
-    #
-    # Parameters: time - the time the run started
     ##########################################################
-    def onStarted(self, time):
-        self.starttime = time
+    def onStarted(self):
+        self.starttime = timer()
         self.started = True
         self.runEnded = False
 
@@ -38,9 +37,9 @@ class State(BaseState.State):
     #
     # Parameters: time - the time the split was ended
     ##########################################################
-    def onSplit(self, map):
+    def onSplit(self):
         self.runEnded = True
-        splitTime = map["system"] - self.starttime
+        splitTime = timer() - self.starttime
         self.currentTime = splitTime
         self.unSaved = True
         if timeh.greater(self.bestTime, splitTime):


### PR DESCRIPTION
1. Don't include all the splits, just all the non-blank ones.
2. Avoid spamming splits when loading a partial state. This also solves the desyncing issue between the main and group timers.
3. States are now responsible for determining the current time on user events.