### PR TITLE
Fix time representation issues

### DIFF
--- a/Components/SplitEditor/AddRunEditor.py
+++ b/Components/SplitEditor/AddRunEditor.py
@@ -73,7 +73,8 @@ class SplitEditor(tk.Frame):
         game = self.game
         category = self.category
         saveData = self.editor.entries.generateGrid()
-        saveData["version"] = "1.1"
+        saveData["offset"] = self.editor.getOffset()
+        saveData["version"] = "1.3"
         saveData["game"] = game
         saveData["category"] = category
         saveData["runs"] = []

--- a/util/lssToPysplit.py
+++ b/util/lssToPysplit.py
@@ -11,7 +11,7 @@ def realTimeToTime(realTime):
     return lssToSplitTime(realTime.text)
 
 
-def lssToSplitTime(lssTime):
+def truncateFront(lssTime):
     time = lssTime[:14]
     if time[0] != "0":
         return time
@@ -24,6 +24,14 @@ def lssToSplitTime(lssTime):
     if time[6] != "0":
         return time[6:]
     return time[7:]
+
+
+def lssToSplitTime(lssTime):
+    time = truncateFront(lssTime)
+    if "." in time:
+        return time + "0"*(len(time) - time.index("."))
+    else:
+        return time + ".00000"
 
 
 def convertName(name):
@@ -188,7 +196,7 @@ def parseXML(xmlfile, mergeList):
     gold_list = getGoldTimes(names, runs)
 
     defaults["bestSegments"] = {
-        "name": "Best Segment",
+        "name": "Best Segments",
         "segments": gold_list
     }
 

--- a/util/timeHelpers.py
+++ b/util/timeHelpers.py
@@ -5,14 +5,9 @@ def zeroPad(finalLength,string):
         string = "0" + string
     return string
 
-def adjustEnd(fracsecs):
-    if fracsecs:
-        string = str(fracsecs)
-    else:
-        string = "0.0"
-    while (len(string) < 11):
-        string = string + "0"
-    return string
+def adjustEnd(fracsecs, precision):
+    intFrac = round(fracsecs*(10**precision))
+    return "." + str(intFrac).rjust(precision, "0")
 
 def trimTime(time):
     index = time.find(".")
@@ -82,6 +77,7 @@ def timeToString(totalSecs,options={}):
     totalSecs = abs(totalSecs)
     if totalSecs > 60 and options["noPrecisionOnMinute"]:
         options["precision"] = 0
+    totalSecs = round(totalSecs, options["precision"])
     fracsecs = totalSecs - int(totalSecs)
     totalSecs = int(totalSecs)
     secs = totalSecs % 60
@@ -100,7 +96,7 @@ def timeToString(totalSecs,options={}):
     else:
         string = string + "0" 
     if options["precision"]:
-        string = string + adjustEnd(fracsecs)[1:options["precision"]+2]
+        string = string + adjustEnd(fracsecs, options["precision"])
     return string
 
 def timesToStringList(arr,options={}):


### PR DESCRIPTION
Because of floating point representation nonsense, sometimes `x-x` is slightly less than 0. We used to just truncate the fractional part in this case, so sometimes 0 would get represented as -0.99. Now we just round to the appropriate precision instead.

Also fixed some bugs I found during testing relating to run creation and converting from .lss.